### PR TITLE
Updated file path for the deploy script

### DIFF
--- a/content/getting-started.adoc
+++ b/content/getting-started.adoc
@@ -6,7 +6,7 @@ Last caveat, there's nothing secret here. Everything on the ISO is available in 
 
 == TL;DR;
 
-Download the ISO indicated in <<Using the ISO>>, complete the installation and reboot. Upon login, run `/opt/rocknsm/rock/ansible/deploy_rock.sh` to accept all the defaults.
+Download the ISO indicated in <<Using the ISO>>, complete the installation and reboot. Upon login, run `/opt/rocknsm/rock/bin/deploy_rock.sh` to accept all the defaults.
 
 Read on for more details and configuration options.
 


### PR DESCRIPTION
Deploy script was moved from /opt/rocknsm/rock/ansible/deploy_rock.sh to /opt/rocknsm/rock/bin/deploy_rock.sh Updated doc to reflect the change.